### PR TITLE
Get (mostly) non-vendored OSX builds working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.vscode
+/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,8 +94,6 @@ if(VENDORED_DEPS)
         message("No ICU Found")
     endif ()
 
-    set(gtest_force_shared_crt ON)
-
     set(OPENSSL_USE_STATIC_LIBS true)
     set(OPENSSL_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/deps/openssl)
 
@@ -103,7 +101,6 @@ if(VENDORED_DEPS)
     add_subdirectory(deps/libevent EXCLUDE_FROM_ALL)
     add_subdirectory(deps/unbound EXCLUDE_FROM_ALL)
     add_subdirectory(deps/spdlog EXCLUDE_FROM_ALL)
-    add_subdirectory(deps/googletest EXCLUDE_FROM_ALL)
 
     set(EVENT_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/deps/libevent/include" ${CMAKE_CURRENT_BINARY_DIR}/deps/libevent/include)
     set(EVENT_LDFLAGS event_core_static event_openssl_static event_extra_static)
@@ -113,22 +110,36 @@ if(VENDORED_DEPS)
 
     set(SPDLOG_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/deps/spdlog/include")
 
-    set(GTEST_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/deps/googletest/googletest/include")
-    set(GTEST_BOTH_LIBRARIES gtest gtest_main)
+    set(GOOGLETEST_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/deps/googletest")
+    find_package(GMock REQUIRED)
 else()
+    if(APPLE)
+        set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:/usr/local/opt/openssl@1.1/lib/pkgconfig:/usr/local/opt/icu4c/lib/pkgconfig/")
+        set(GOOGLETEST_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/deps/googletest")
+    elseif(UNIX)
+        # Nothing to do for Linux
+    else()
+        message(FATAL_ERROR "Non-vendored builds not supported on Windows yet")
+    endif()
+
     # Find libs with pkg-config
     find_package(PkgConfig)
     pkg_check_modules(SPDLOG spdlog REQUIRED)
-    set(SPDLOG_INCLUDE_DIRS "/usr/include/spdlog/") # Busted pkg-config file above
     pkg_check_modules(EVENT libevent libevent_openssl libevent_pthreads REQUIRED)
     pkg_check_modules(UNBOUND libunbound REQUIRED)
     pkg_check_modules(ICU icu-uc REQUIRED)
     add_definitions(-DHAVE_ICU)
 
     find_package(GMock REQUIRED)
+
+    if(APPLE)
+        set(SPDLOG_INCLUDE_DIRS "/usr/local/include/") # Busted pkg-config for SPDLOG
+    elseif(UNIX)
+        set(SPDLOG_INCLUDE_DIRS "/usr/include/spdlog/") # Busted pkg-config for SPDLOG
+    endif()
 endif()
 
-find_package(OpenSSL REQUIRED)
+find_package(OpenSSL 1.1.0 REQUIRED)
 
 set(FILTER_SOURCES
     src/filters/disco-cache.cc

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,9 @@ COPY metre.conf.xml src/
 RUN set -eux; \
     mkdir build; \
     cd build; \
-    CC=clang CXX=clang++ cmake \
+    cmake \
+    	-DCMAKE_C_COMPILER=/usr/bin/clang \
+    	-DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
         -DCMAKE_INSTALL_PREFIX=/app/install \
         -DCMAKE_BUILD_TYPE=Release \
         -DVENDORED_DEPS=OFF \

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,33 @@ dhparams: gen/dh1024.cc gen/dh2048.cc gen/dh4096.cc
 
 gen/dh%.cc:
 	./deps/openssl/apps/openssl dhparam -C -noout $* >$@
+
+apt-deps:
+	apt-get install --quiet --no-install-recommends \
+		clang \
+		cmake \
+		googletest \
+		libc++-dev \
+		libc++abi-dev \
+		libevent-dev \
+		libexpat-dev \
+		libicu-dev \
+		libspdlog-dev \
+		libssl-dev \
+		libunbound-dev \
+		ninja-build \
+		pkg-config
+
+brew-deps:
+	brew install \
+		icu4c \
+		libevent \
+		ninja \
+		openssl@1.1 \
+		spdlog \
+		unbound
+
+eclipse:
+	mkdir -p ../metre-eclipse-build
+	# -DCMAKE_CXX_COMPILER_ARG1 is a trick to make the Eclipse project generate with the correct C++ version flags
+	cd ../metre-eclipse-build && cmake -G'Eclipse CDT4 - Ninja' -DCMAKE_CXX_COMPILER_ARG1="-std=c++17" -DVENDORED_DEPS=OFF ../metre

--- a/cmake/modules/FindGMock.cmake
+++ b/cmake/modules/FindGMock.cmake
@@ -28,65 +28,31 @@
 # NOTE: Due to the way this package finder is implemented, do not attempt
 # to find the GMock package more than once.
 
-find_package(Threads)
-
-if (EXISTS "/usr/src/googletest")
-    # As of version 1.8.0
-    set(GMOCK_SOURCE_DIR "/usr/src/googletest/googlemock" CACHE PATH "gmock source directory")
+if(DEFINED GOOGLETEST_ROOT_DIR)
+    set(GMOCK_SOURCE_DIR "${GOOGLETEST_ROOT_DIR}/googlemock" CACHE PATH "gmock source directory")
     set(GMOCK_INCLUDE_DIRS "${GMOCK_SOURCE_DIR}/include" CACHE PATH "gmock source include directory")
-    set(GTEST_INCLUDE_DIRS "/usr/src/googletest/googletest/include" CACHE PATH "gtest source include directory")
+    set(GTEST_SOURCE_DIR "${GOOGLETEST_ROOT_DIR}/googletest" CACHE PATH "gmock source directory")
+    set(GTEST_INCLUDE_DIRS "${GTEST_SOURCE_DIR}/include" CACHE PATH "gtest source include directory")
+elseif(EXISTS "/usr/src/googletest")
+    # As of version 1.8.0
+    set(GOOGLETEST_ROOT_DIR "/usr/src/googletest")
+    set(GMOCK_SOURCE_DIR "${GOOGLETEST_ROOT_DIR}/googlemock" CACHE PATH "gmock source directory")
+    set(GMOCK_INCLUDE_DIRS "${GMOCK_SOURCE_DIR}/include" CACHE PATH "gmock source include directory")
+    set(GTEST_SOURCE_DIR "${GOOGLETEST_ROOT_DIR}/googletest" CACHE PATH "gmock source directory")
+    set(GTEST_INCLUDE_DIRS "${GTEST_SOURCE_DIR}/include" CACHE PATH "gtest source include directory")
 else()
-    set(GMOCK_SOURCE_DIR "/usr/src/gmock" CACHE PATH "gmock source directory")
+    set(GOOGLETEST_ROOT_DIR "/usr/src/gmock" CACHE PATH "gmock source directory")
     set(GMOCK_INCLUDE_DIRS "/usr/include" CACHE PATH "gmock source include directory")
     set(GTEST_INCLUDE_DIRS "/usr/include" CACHE PATH "gtest source include directory")
 endif()
 
-# We add -g so we get debug info for the gtest stack frames with gdb.
-# The warnings are suppressed so we get a noise-free build for gtest and gmock if the caller
-# has these warnings enabled.
-set(findgmock_cxx_flags "${CMAKE_CXX_FLAGS} -g -Wno-old-style-cast -Wno-missing-field-initializers -Wno-ctor-dtor-privacy -Wno-switch-default")
+# Prevent GoogleTest from overriding our compiler/linker options
+# when building with Visual Studio
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
-set(findgmock_bin_dir "${CMAKE_CURRENT_BINARY_DIR}/gmock")
-set(findgmock_gtest_lib "${findgmock_bin_dir}/gtest/libgtest.a")
-set(findgmock_gtest_main_lib "${findgmock_bin_dir}/gtest/libgtest_main.a")
-set(findgmock_gmock_lib "${findgmock_bin_dir}/libgmock.a")
-set(findgmock_gmock_main_lib "${findgmock_bin_dir}/libgmock_main.a")
+add_subdirectory("${GOOGLETEST_ROOT_DIR}" "${CMAKE_BINARY_DIR}/googletest" EXCLUDE_FROM_ALL)
 
-include(ExternalProject)
-ExternalProject_Add(GMock SOURCE_DIR "${GMOCK_SOURCE_DIR}"
-                          BINARY_DIR "${findgmock_bin_dir}"
-                          BUILD_BYPRODUCTS "${findgmock_gtest_lib}"
-                                           "${findgmock_gtest_main_lib}"
-                                           "${findgmock_gmock_lib}"
-                                           "${findgmock_gmock_main_lib}"
-                          INSTALL_COMMAND ""
-                          CMAKE_ARGS "-DCMAKE_CXX_FLAGS=${findgmock_cxx_flags}")
-
-add_library(gtest INTERFACE)
-target_include_directories(gtest INTERFACE ${GTEST_INCLUDE_DIRS})
-target_link_libraries(gtest INTERFACE ${findgmock_gtest_lib} ${CMAKE_THREAD_LIBS_INIT})
-add_dependencies(gtest GMock)
-
-add_library(gtest_main INTERFACE)
-target_include_directories(gtest_main INTERFACE ${GTEST_INCLUDE_DIRS})
-target_link_libraries(gtest_main INTERFACE ${findgmock_gtest_main_lib} gtest)
-
-add_library(gmock INTERFACE)
-target_include_directories(gmock INTERFACE ${GMOCK_INCLUDE_DIRS})
-target_link_libraries(gmock INTERFACE ${findgmock_gmock_lib} gtest)
-
-add_library(gmock_main INTERFACE)
-target_include_directories(gmock_main INTERFACE ${GMOCK_INCLUDE_DIRS})
-target_link_libraries(gmock_main INTERFACE ${findgmock_gmock_main_lib} gmock)
-
-set(GTEST_LIBRARIES gtest)
-set(GTEST_MAIN_LIBRARIES gtest_main)
-set(GMOCK_LIBRARIES gmock gmock_main)
-set(GTEST_BOTH_LIBRARIES ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES})
-
-unset(findgmock_cxx_flags)
-unset(findgmock_bin_dir)
-unset(findgmock_gtest_lib)
-unset(findgmock_gtest_main_lib)
-unset(findgmock_gmock_lib)
-unset(findgmock_gmock_main_lib)
+set(GTEST_LIBRARIES gtest CACHE PATH "gtest libraries")
+set(GTEST_MAIN_LIBRARIES gtest_main CACHE PATH "gtest libraries")
+set(GMOCK_LIBRARIES gmock gmock_main CACHE PATH "gtest libraries")
+set(GTEST_BOTH_LIBRARIES ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES} CACHE PATH "gtest libraries")


### PR DESCRIPTION
- Depends on https://github.com/Homebrew/homebrew-core/pull/38737
- Updated vendored version of googletest to release 1.8.1