### PR TITLE
Fix address lookup undefined behaviour

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -320,6 +320,8 @@ namespace Metre {
     private:
         static int verify_callback_cb(int preverify_ok, struct x509_store_ctx_st *);
 
+        void create_domain(std::string const &dom);
+
         bool m_fetch_crls = true;
         std::string m_config_str;
         std::string m_default_domain;

--- a/metre.conf.xml
+++ b/metre.conf.xml
@@ -15,60 +15,27 @@
     <dnssec>/home/dwd/src/metre/keys</dnssec>
     <!-- DNSSEC root keys file. -->
   </globals>
-  <local>
-    <!-- Domains actually serviced by this instance are listed in the Local stanza.
-          This could be empty if the server is acting purely as a forwarding agent.
-          All internal domains do, currently, is respond to XEP-0199 pings...
-          -->
-    <domain name='cridland.im'>
-        <x509 chain='./chain.pem'
-              pkey='./privkey.pem'/><!-- X.509 information, specifically a chain file and a private key file, in PEM format. -->
-    </domain>
-  </local>
   <remote>
     <!-- The Remote stanza lists known external domains and parameters for connections.
           There is a special "default" entry which is used to connect to unlisted domains - if this
           is not present, it will simply not connect to unlisted domains.
         -->
+    <domain name="cridland.im">
+      <transport type="114">
+        <auth type="secret">ThreadsMagic!</auth>
+      </transport>
+    </domain>
     <any>
       <!-- This is a special catch-all.
             If the code needs a domain and there isn't one, it'll use this.-->
-      <transport type='s2s' sec='tls'> <!-- Transport blocks contain a transport type (s2s or 114), and required security level (none or tls) -->
-        <!-- <any/> contains defaults, so these authentication methods will be used unless a domain specifies something else. -->
-        <auth type="pkix"/><!-- PKIX authentication is SASL EXTERNAL based, X.509 Strong Authentication. Certificates, basically. -->
+      <transport type='s2s'
+                 sec='none'> <!-- Transport blocks contain a transport type (s2s or 114), and required security level (none or tls) -->
         <auth type="dialback"/><!-- Dialback authentication is reliant on DNS. Metre always checks DNSSEC, but not all domains have it and it won't enforce.. -->
       </transport>
-      <!-- Defaults for what local domains will offer over TLS -->
-      <dhparam size='4096'/><!-- DH Parameter sizes - some domains will not support higher than 2048, others no higher than 1024. -->
-        <x509 chain='./chain.pem'
-              pkey='./privkey.pem'/><!-- X.509 information, specifically a chain file and a private key file, in PEM format. -->
     </any>
-    <domain name='dave.cridland.net' forward='true'><!-- Domains set to forward will be responded to locally, and the stanzas passed through. -->
-      <transport type='s2s' sec='false'>
-        <!-- If there's any auth options here this will override defaults. -->
-        <auth type='pkix'/><!-- PKIX authentication is SASL EXTERNAL based, X.509 Strong Authentication. Certificates, basically. -->
-        <auth type='dialback'/>
-      </transport>
-        <x509 chain='./chain.pem'
-              pkey='./privkey.pem'/><!-- X.509 information, specifically a chain file and a private key file, in PEM format. -->
-      <dhparam size='1024'/>
-      <dns><!-- Override DNS records. -->
-        <!-- <srv host='peirce.dave.cridland.net' port='5269'/>
-        <host name='peirce.dave.cridland.net' a='217.155.137.61'/>
-        <tlsa hostname='peirce.dave.cridland.net' port='5269' certusage='DomainCert' selector='FullCert' matchtype='Full'>./cridland.der</tlsa> -->
-      </dns>
-    </domain>
-    <domain name="surevine.com">
-      <!-- <dns dnssec="true"/> - Setting DNSSEC to true means Metre rejects any unsigned records. -->
-    </domain>
-    <domain name='channels.cridland.im' forward='true'> <!-- Components are also domains - but use a different transport. -->
-      <transport type='114' sec='none'>
-        <auth type='secret'>secret</auth><!-- XEP-0114 components authentication with a shared secret. -->
-      </transport>
-    </domain>
-    <domain name='topics.cridland.im' forward='true'> <!-- Component. -->
-      <transport type='114' sec='none'>
-        <auth type='secret'>secret</auth>
+    <domain name="blah.dave.cridland.net">
+      <transport type="s2s" sec="none">
+        <auth type="dialback"/>
       </transport>
     </domain>
   </remote>

--- a/src/config.cc
+++ b/src/config.cc
@@ -677,7 +677,7 @@ void Config::load(std::string const &filename) {
         auto any = external->first_node("any");
         if (any) {
             std::unique_ptr<Config::Domain> dom = parse_domain(nullptr, any, S2S);
-            any_domain = &*dom; // Save this pointer.
+            any_domain = dom.get(); // Save this pointer.
             m_domains[dom->domain()] = std::move(dom);
         } else {
             m_domains[""] = std::make_unique<Config::Domain>("", INTERNAL, false, true, true, true, true, false,
@@ -1601,7 +1601,7 @@ Config::addr_callback_t &Config::Domain::AddressLookup(std::string const &ihostn
     }
     auto it = arecs->find(hostname);
     if (it != arecs->end()) {
-        auto addr = &*(it->second);
+        auto addr = it->second.get();
         Router::defer([addr, this]() {
             m_a_pending[addr->hostname].emit(addr);
         });
@@ -1680,7 +1680,7 @@ Config::tlsa_callback_t &Config::Domain::TlsaLookup(unsigned short port, std::st
     }
     auto it = recs->find(domain);
     if (it != recs->end()) {
-        auto addr = &*(it->second);
+        auto addr = it->second.get();
         Router::defer([addr, this]() {
             m_tlsa_pending[addr->domain].emit(addr);
         });


### PR DESCRIPTION
This contains a fix for the undefined behaviour when dereferencing a null unique_ptr.

Unlike a normal pointer, the compiler assumes that such a deference is always true:

```c++
std::unique_ptr<T> t;
auto ptr = &*t;
assert(ptr); // True!
```

This PR also tidies the runtime domain creation code, and fixes other cases that didn't seem to be causing problems, but have me nervous now.