### PR TITLE
Refactor resolver into own class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ endif (UNIX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-add_definitions(-DSIGSLOT_COROUTINES)
+add_definitions(-DSIGSLOT_COROUTINES -DSIGSLOT_RESUME_OVERRIDE)
 
 if(UNIX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -O0 -g -fcoroutines-ts -stdlib=libc++")
@@ -217,7 +217,7 @@ set(SOURCE_FILES
     src/stanza.cc
     src/starttls.cc
     src/xmlstream.cc
-)
+        include/sigslot.h include/core.h)
 
 if(UNIX)
     list(APPEND SOURCE_FILES src/linuxmain.cc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ endif (UNIX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-add_definitions(-DSIGSLOT_COROUTINES -DSIGSLOT_RESUME_OVERRIDE)
+add_definitions(-DSIGSLOT_COROUTINES)
 
 if(UNIX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -O0 -g -fcoroutines-ts -stdlib=libc++")
@@ -247,6 +247,8 @@ target_link_libraries(metre PRIVATE
     OpenSSL::SSL
     OpenSSL::Crypto
 )
+
+target_compile_definitions(metre PRIVATE -DSIGSLOT_RESUME_OVERRIDE)
 
 if (UNIX)
     target_include_directories(metre PRIVATE

--- a/include/config.h
+++ b/include/config.h
@@ -28,6 +28,7 @@ SOFTWARE.
 
 #include <string>
 #include <map>
+#include <unordered_set>
 #include <optional>
 #include <memory>
 #include <list>
@@ -65,6 +66,8 @@ namespace Metre {
         public:
             Resolver(Domain const &);
 
+            ~Resolver();
+
             /* DNS */
             srv_callback_t &SrvLookup(std::string const &domain);
 
@@ -91,6 +94,7 @@ namespace Metre {
             std::map<std::string, addr_callback_t> m_a_pending;
             std::map<std::string, tlsa_callback_t> m_tlsa_pending;
             std::shared_ptr<spdlog::logger> m_logger;
+            std::unordered_set<int> m_queries;
         };
 
         class Domain {

--- a/include/core.h
+++ b/include/core.h
@@ -1,0 +1,47 @@
+//
+// Created by dwd on 13/04/19.
+//
+
+#include "defs.h"
+
+#ifndef METRE_CORE_H
+#define METRE_CORE_H
+
+struct event_base;
+struct sockaddr;
+
+namespace Metre {
+    namespace Router {
+        std::shared_ptr<NetSession> session_by_address(std::string const &remote_addr, unsigned short port);
+
+        std::shared_ptr<NetSession> session_by_domain(std::string const &remote_addr);
+
+        void register_session_domain(std::string const &dom, NetSession &);
+
+        std::shared_ptr<NetSession>
+        connect(std::string const &fromd, std::string const &tod, std::string const &hostname, struct sockaddr *addr,
+                unsigned short port, SESSION_TYPE stype, TLS_MODE tls_mode);
+
+        std::shared_ptr<NetSession> session_by_stream_id(std::string const &stream_id);
+
+        std::shared_ptr<NetSession> session_by_serial(long long int);
+
+        void register_stream_id(std::string const &, NetSession &);
+
+        void unregister_stream_id(std::string const &);
+
+        void defer(std::function<void()> &&);
+
+        void defer(std::function<void()> &&, std::size_t seconds);
+
+        void main(std::function<bool()> const &);
+
+        void reload();
+
+        void quit();
+
+        struct event_base *event_base();
+    }
+}
+
+#endif //METRE_CORE_H

--- a/include/datastore.h
+++ b/include/datastore.h
@@ -8,7 +8,7 @@
 #include <string>
 #include <event2/event.h>
 #include <functional>
-#include <sigslot/sigslot.h>
+#include "sigslot.h"
 #include <map>
 #include <optional>
 

--- a/include/defs.h
+++ b/include/defs.h
@@ -60,6 +60,8 @@ namespace Metre {
     class XMLStream;
 
     class Route;
+
+    class NetSession;
 }
 
 #ifndef SIGSLOT_PURE_ISO

--- a/include/dns.h
+++ b/include/dns.h
@@ -27,7 +27,7 @@ SOFTWARE.
 #define METRE_DNS_H
 
 #include "defs.h"
-#include <sigslot/sigslot.h>
+#include "sigslot.h"
 #include <string>
 #include <vector>
 // For struct sockaddr_storage :

--- a/include/endpoint.h
+++ b/include/endpoint.h
@@ -6,7 +6,7 @@
 #define METRE_ENDPOINT_H
 
 #include <random>
-#include <sigslot/sigslot.h>
+#include "sigslot.h"
 #include <sigslot/tasklet.h>
 #include "jid.h"
 #include "stanza.h"

--- a/include/http.h
+++ b/include/http.h
@@ -5,7 +5,7 @@
 #ifndef METRE_HTTP_H
 #define METRE_HTTP_H
 
-#include <sigslot/sigslot.h>
+#include "sigslot.h"
 #include <map>
 
 struct evhttp_request;

--- a/include/netsession.h
+++ b/include/netsession.h
@@ -29,7 +29,7 @@ SOFTWARE.
 #include <string>
 #include "defs.h"
 #include "rapidxml.hpp"
-#include "sigslot/sigslot.h"
+#include "sigslot.h"
 #include "config.h"
 
 // fwd:
@@ -45,6 +45,7 @@ namespace Metre {
         struct bufferevent *m_bev;
         std::unique_ptr<XMLStream> m_xml_stream;
         bool m_in_progress = false;
+        std::shared_ptr<spdlog::logger> m_logger;
     public:
         NetSession(unsigned long long serial, struct bufferevent *bev, Config::Listener const *listen); /* Inbound */
         NetSession(unsigned long long serial, struct bufferevent *bev, std::string const &stream_from,

--- a/include/router.h
+++ b/include/router.h
@@ -29,6 +29,7 @@ SOFTWARE.
 #include "defs.h"
 #include "jid.h"
 #include "stanza.h"
+#include "core.h"
 #include "sigslot.h"
 #include "sigslot/tasklet.h"
 

--- a/include/router.h
+++ b/include/router.h
@@ -29,7 +29,7 @@ SOFTWARE.
 #include "defs.h"
 #include "jid.h"
 #include "stanza.h"
-#include "dns.h"
+#include "sigslot.h"
 #include "sigslot/tasklet.h"
 
 #include <string>
@@ -37,8 +37,6 @@ SOFTWARE.
 #include <queue>
 #include <map>
 #include <spdlog/logger.h>
-
-struct event_base;
 
 namespace Metre {
     class NetSession;
@@ -107,37 +105,6 @@ namespace Metre {
         static RouteTable &routeTable(Jid const &);
     };
 
-    namespace Router {
-        std::shared_ptr<NetSession> session_by_address(std::string const &remote_addr, unsigned short port);
-
-        std::shared_ptr<NetSession> session_by_domain(std::string const &remote_addr);
-
-        void register_session_domain(std::string const &dom, NetSession &);
-
-        std::shared_ptr<NetSession>
-        connect(std::string const &fromd, std::string const &tod, std::string const &hostname, struct sockaddr *addr,
-                unsigned short port, SESSION_TYPE stype, TLS_MODE tls_mode);
-
-        std::shared_ptr<NetSession> session_by_stream_id(std::string const &stream_id);
-
-        std::shared_ptr<NetSession> session_by_serial(long long int);
-
-        void register_stream_id(std::string const &, NetSession &);
-
-        void unregister_stream_id(std::string const &);
-
-        void defer(std::function<void()> &&);
-
-        void defer(std::function<void()> &&, std::size_t seconds);
-
-        void main(std::function<bool()> const &);
-
-        void reload();
-
-        void quit();
-
-        struct event_base * event_base();
-    }
 }
 
 #endif

--- a/include/sigslot.h
+++ b/include/sigslot.h
@@ -1,0 +1,17 @@
+//
+// Created by dwd on 13/04/19.
+//
+
+#ifndef METRE_SIGSLOT_H
+#define METRE_SIGSLOT_H
+
+#include <experimental/coroutine>
+#include "core.h"
+
+namespace sigslot {
+    void resume(std::experimental::coroutine_handle<> coro);
+}
+
+#include <sigslot/sigslot.h>
+
+#endif //METRE_SIGSLOT_H

--- a/include/sigslot.h
+++ b/include/sigslot.h
@@ -5,12 +5,14 @@
 #ifndef METRE_SIGSLOT_H
 #define METRE_SIGSLOT_H
 
+#ifdef SIGSLOT_RESUME_OVERRIDE
 #include <experimental/coroutine>
 #include "core.h"
 
 namespace sigslot {
     void resume(std::experimental::coroutine_handle<> coro);
 }
+#endif
 
 #include <sigslot/sigslot.h>
 

--- a/include/sql.h
+++ b/include/sql.h
@@ -7,7 +7,7 @@
 
 #include <functional>
 #include <memory>
-#include <sigslot/sigslot.h>
+#include "sigslot.h"
 #include <postgresql/libpq-fe.h>
 
 namespace Metre {

--- a/include/xmlstream.h
+++ b/include/xmlstream.h
@@ -31,7 +31,7 @@ SOFTWARE.
 #include <optional>
 #include <memory>
 #include <vector>
-#include "sigslot/sigslot.h"
+#include "sigslot.h"
 #include "rapidxml.hpp"
 #include "feature.h"
 #include "xmppexcept.h"
@@ -83,12 +83,17 @@ namespace Metre {
         std::map<std::string, sigslot::signal<Stanza const &>> m_response_callbacks;
         std::list<std::shared_ptr<sigslot::tasklet<bool>>> m_tasks;
         int m_in_flight = 0; // Tasks in flight.
+        std::shared_ptr<spdlog::logger> m_logger;
 
     public:
         XMLStream(NetSession *owner, SESSION_DIRECTION dir, SESSION_TYPE type);
 
         XMLStream(NetSession *owner, SESSION_DIRECTION dir, SESSION_TYPE type, std::string const &stream_from,
                   std::string const &stream_to);
+
+        spdlog::logger &logger() const {
+            return *m_logger;
+        }
 
         size_t process(unsigned char *, size_t);
 

--- a/src/components.cc
+++ b/src/components.cc
@@ -97,8 +97,6 @@ namespace {
                 std::string const handshake_offered{node->value(), node->value_size()};
                 std::string const handshake_expected = handshake_content();
                 if (handshake_offered != handshake_expected) {
-                    METRE_LOG(Metre::Log::DEBUG, "RX: '" << handshake_offered << "'");
-                    METRE_LOG(Metre::Log::DEBUG, "TX: '" << handshake_expected << "'");
                     throw not_authorized("Component handshake failure");
                 }
 

--- a/src/dialback.cc
+++ b/src/dialback.cc
@@ -68,7 +68,7 @@ namespace {
         bool negotiate(rapidxml::xml_node<> *) override { // Note that this offer, unusually, can be nullptr.
             if (!m_stream.secured() && (Config::config().domain(m_stream.local_domain()).require_tls() ||
                                         Config::config().domain(m_stream.remote_domain()).require_tls())) {
-                METRE_LOG(Metre::Log::DEBUG, "Supressed dialback due to missing required TLS");
+                m_stream.logger().info("Supressed dialback due to missing required TLS");
                 return false;
             }
             m_stream.set_auth_ready();
@@ -165,12 +165,12 @@ namespace {
         void verify(DB::Verify const &v) {
             std::shared_ptr<NetSession> session = Router::session_by_stream_id(*v.id());
             DB::Type validity = DB::INVALID;
-            METRE_LOG(Log::DEBUG, "Handling db:verify");
+            m_stream.logger().debug("Handling db:verify");
             if (session) {
-                METRE_LOG(Log::DEBUG, "[NS" << session->serial() << "] session found.");
+                m_stream.logger().debug("Verify [NS{}] session found.", session->serial());
                 if (session->xml_stream().s2s_auth_pair(v.to().domain(), v.from().domain(), OUTBOUND) >=
                     XMLStream::REQUESTED) {
-                    METRE_LOG(Log::DEBUG, "[NS" << session->serial() << "] Auth State is correct.");
+                    m_stream.logger().debug("Verify [NS{}] Auth State is correct.", session->serial());
                     std::string expected = Config::config().dialback_key(*v.id(), v.to().domain(), v.from().domain());
                     if (v.key() == expected) validity = DB::VALID;
                 }

--- a/src/jabberserver.cc
+++ b/src/jabberserver.cc
@@ -91,7 +91,7 @@ namespace {
                         }
                     }
                     if (DROP == Config::config().domain(to.domain()).filter(INBOUND, *s)) {
-                        METRE_LOG(Log::INFO, "Stanza discarded by filters");
+                        m_stream.logger().info("Stanza discarded by filters");
                         co_return true;
                     }
                     if (Config::config().domain(to.domain()).transport_type() == INTERNAL) {

--- a/src/mainloop.cc
+++ b/src/mainloop.cc
@@ -48,7 +48,7 @@ SOFTWARE.
 #include <cerrno>
 #include <cstring>
 #include <atomic>
-#include "sigslot/sigslot.h"
+#include "sigslot.h"
 #include "dns.h"
 #include "config.h"
 #include "log.h"
@@ -435,5 +435,14 @@ namespace Metre {
         struct event_base * event_base() {
             return Mainloop::s_mainloop->event_base();
         }
+    }
+}
+
+namespace sigslot {
+    void resume(std::experimental::coroutine_handle<> coro) {
+        Metre::Router::defer([=]() {
+            std::experimental::coroutine_handle<> c = coro;
+            c.resume();
+        });
     }
 }

--- a/src/stanza.cc
+++ b/src/stanza.cc
@@ -59,7 +59,6 @@ void Stanza::freeze() {
         return;
     }
     m_payload_str.assign(m_payload, m_payload_l);
-    METRE_LOG(Metre::Log::DEBUG, "Frozen stanza: " + m_payload_str);
     m_payload = m_payload_str.data();
     m_node = nullptr;
 }

--- a/src/starttls.cc
+++ b/src/starttls.cc
@@ -262,7 +262,9 @@ namespace Metre {
         }
         X509_VERIFY_PARAM_set1_host(vpm, route.domain().c_str(), route.domain().size());
         // Add RFC 6125 additional names.
-        auto srv = *co_await Config::config().domain(route.domain()).SrvLookup(route.domain());
+        auto res = Config::config().domain(route.domain()).resolver();
+        auto srv = co_await
+        res->SrvLookup(route.domain());
         if (srv.error.empty()) {
             if (srv.dnssec) {
                 for (auto &rr : srv.rrs) {
@@ -287,7 +289,8 @@ namespace Metre {
         bool dane_present = false;
         if (srv.dnssec) {
             for (auto &rr : srv.rrs) {
-                auto tlsa = *co_await Config::config().domain(route.domain()).TlsaLookup(rr.port, rr.hostname);
+                auto tlsa = co_await
+                res->TlsaLookup(rr.port, rr.hostname);
                 if (!tlsa.dnssec) continue;
                 if (!tlsa.error.empty()) continue;
                 dane_present = true;


### PR DESCRIPTION
Now, the resolver is owned by the caller, and so
we no longer need to copy results.

In addition, overlapping resolutions are no longer
a concern.